### PR TITLE
Fix #14 by adding a `binary` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ NodeJS.call({"math", :add}, [1, 2]) # => {:ok, 3}
 NodeJS.call({"math", :sub}, [1, 2]) # => {:ok, -1}
 ```
 
+In order to cope with Unicode character it is necessary to specify the `binary` option:
+
+```elixir
+NodeJS.call("echo", ["’"], binary: true) # => {:ok, "’"}
+```
+
 ### There Are Rules & Limitations (Unfortunately)
 
 * Function arguments must be serializable to JSON.

--- a/lib/nodejs/supervisor.ex
+++ b/lib/nodejs/supervisor.ex
@@ -31,10 +31,11 @@ defmodule NodeJS.Supervisor do
 
   defp to_transaction(module, args, opts) do
     timeout = Keyword.get(opts, :timeout, @timeout)
+    binary = Keyword.get(opts, :binary, false)
 
     func = fn pid ->
       try do
-        GenServer.call(pid, {module, args}, timeout)
+        GenServer.call(pid, {module, args, binary}, timeout)
       catch
         :exit, {:timeout, {GenServer, :call, _}} ->
           {:error, "Call timed out."}

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -51,13 +51,22 @@ defmodule NodeJS.Worker do
     end
   end
 
+  defp decode_binary(data, binary) do
+    if binary === true do
+      :binary.list_to_bin(data)
+    else
+      data
+    end
+  end
+
   @doc false
-  def handle_call({module, args}, _from, [_, port] = state) when is_tuple(module) do
+  def handle_call({module, args, binary}, _from, [_, port] = state) when is_tuple(module) do
     body = Jason.encode!([Tuple.to_list(module), args])
     Port.command(port, "#{body}\n")
 
     response =
       get_response()
+      |> decode_binary(binary)
       |> decode()
 
     {:reply, response, state}

--- a/test/js/.gitignore
+++ b/test/js/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn.lock

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -130,4 +130,10 @@ defmodule NodeJS.Test do
       assert {:ok, 1111} = NodeJS.call("slow-async-echo", [1111])
     end
   end
+
+  describe "strange characters" do
+    test "are transferred properly between js and elixir" do
+      assert {:ok, "’"} = NodeJS.call("default-function-echo", ["’"])
+    end
+  end
 end

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -133,7 +133,7 @@ defmodule NodeJS.Test do
 
   describe "strange characters" do
     test "are transferred properly between js and elixir" do
-      assert {:ok, "’"} = NodeJS.call("default-function-echo", ["’"])
+      assert {:ok, "’"} = NodeJS.call("default-function-echo", ["’"], binary: true)
     end
   end
 end


### PR DESCRIPTION
Added a `binary` option to support receiving unicode characters.