### PR TITLE
Update NODE_PATH with additional directory paths

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 21.0
-elixir 1.6.6-otp-21
-nodejs 10.0.0
+erlang 21.1
+elixir 1.9.1-otp-21
+nodejs 12.9.0

--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ NodeJS.call("echo", ["’"], binary: true) # => {:ok, "’"}
 - Return values must be serializable to JSON. (Objects with circular references will definitely fail.)
 - Modules must be requested relative to the `path` that was given to the `Supervisor`.
   E.g., for a `path` of `/node_app_root` and a file `/node_app_root/foo/index.js` your module request should be for `"foo/index.js"` or `"foo/index"` or `"foo"`.
-- To reference `node_modules` dependecies, do one of the following:
-  - Make local modules that re-export the functions you want.
-  - Request the module as `"node_modules/<name>"`. (Not `"<name>"` as you would in Node.)
 
 ### Running the tests
 

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -16,8 +16,18 @@ defmodule NodeJS.Worker do
     GenServer.start_link(__MODULE__, module_path)
   end
 
+  # Node.js REPL Service
   defp node_service_path() do
     Path.join(:code.priv_dir(:nodejs), "server.js")
+  end
+
+  # Specifies the NODE_PATH for the REPL service to require modules from. We specify
+  # both the root path and `/node_modules` folder relative to the root path. This is
+  # to specify the entry point that the REPL service runs code from.
+  defp node_path(module_path) do
+    [module_path, module_path <> "/node_modules"]
+    |> Enum.join(":")
+    |> String.to_charlist()
   end
 
   # --- GenServer Callbacks ---
@@ -30,7 +40,7 @@ defmodule NodeJS.Worker do
         {:spawn_executable, node},
         line: @read_chunk_size,
         env: [
-          {'NODE_PATH', String.to_charlist(module_path)},
+          {'NODE_PATH', node_path(module_path)},
           {'WRITE_CHUNK_SIZE', String.to_charlist("#{@read_chunk_size}")}
         ],
         args: [node_service_path()]

--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,9 @@ defmodule NodeJS.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, "~> 1.0"},
       {:ex_doc, "~> 0.20.0", only: :dev},
       {:excoveralls, "~> 0.11.0", only: :test},
+      {:jason, "~> 1.0"},
       {:poolboy, "~> 1.5.1"}
     ]
   end

--- a/priv/server.js
+++ b/priv/server.js
@@ -1,28 +1,14 @@
 const path = require('path')
 const readline = require('readline')
-const { MODULE_SEARCH_PATH } = process.env
 const WRITE_CHUNK_SIZE = parseInt(process.env.WRITE_CHUNK_SIZE, 10)
 
-function rewritePath(oldPath) {
-  return oldPath
-  const [_1, _2, relative, name] = oldPath.match(/^((\.\.?)\/)?(.*)$/)
-
-  if (relative) {
-    return path.join(MODULE_SEARCH_PATH, relative, name)
-  }
-
-  return path.join(MODULE_SEARCH_PATH, 'node_modules', name)
-}
-
 function requireModule(modulePath) {
-  const newPath = rewritePath(modulePath)
-
   // When not running in production mode, refresh the cache on each call.
   if (process.env.NODE_ENV !== 'production') {
-    delete require.cache[require.resolve(newPath)]
+    delete require.cache[require.resolve(modulePath)]
   }
 
-  return require(newPath)
+  return require(modulePath)
 }
 
 function getAncestor(parent, [key, ...keys]) {

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -69,14 +69,14 @@ defmodule NodeJS.Test do
   describe "calling keyed-functions getIncompatibleReturnValue" do
     test "returns a JSON.stringify error" do
       assert {:error, msg} = NodeJS.call({"keyed-functions", :getIncompatibleReturnValue})
-      assert js_error_message(msg) === "TypeError: Converting circular structure to JSON"
+      assert msg =~ "Converting circular structure to JSON"
     end
   end
 
   describe "calling things that are not functions: " do
     test "module does not exist" do
       assert {:error, msg} = NodeJS.call("idontexist")
-      assert js_error_message(msg) === "Error: Cannot find module 'idontexist'"
+      assert msg =~ "Error: Cannot find module 'idontexist'"
     end
 
     test "function does not exist" do


### PR DESCRIPTION
This should address what was mentioned in PR #12 without any `BREAKING CHANGES` :crossed_fingers:.

The goal of this PR is to achieve the following:

- Allow us to call `require()` inside of the code we are calling without having to deal with any awkward `module resolution` by re-exporting/etc. This should minimize the amount of restrictions/limitations we have when dealing with requiring modules that are located inside of the typical `node_modules` directory.
- Removes some unused code in the `priv/server.js` file which had an early return in the `rewriteRequire` function. I think we can re-introduce this again once we figure out the `MODULE_SEARCH_PATH` logic, which has to do with how you are calling `require()`.

This is done by simply expanding the `NODE_PATH` we already set by including the `/node_modules` directory for the path specified. It's a valid workaround and does address some of the limitations around the `node_modules` directory.

My understanding is that `path` is considered our "working directory" in which everything would be ran from. It would make sense for us to also include the `/node_modules` as part of the `NODE_PATH` lookup if this is true.