### PR TITLE
Fix NODE_PATH for Windows

### DIFF
--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -26,8 +26,15 @@ defmodule NodeJS.Worker do
   # to specify the entry point that the REPL service runs code from.
   defp node_path(module_path) do
     [module_path, module_path <> "/node_modules"]
-    |> Enum.join(":")
+    |> Enum.join(node_path_separator())
     |> String.to_charlist()
+  end
+
+  defp node_path_separator do
+    case :os.type() do
+      {:win32, _} -> ";"
+      _ -> ":"
+    end
   end
 
   # --- GenServer Callbacks ---


### PR DESCRIPTION
Fixes #34 

This implements `node_path_separator/0` to determine which separator to use when combining the `PATH` used for `NODE_PATH`.