### PR TITLE
Added a `name` option

### DIFF
--- a/lib/nodejs/supervisor.ex
+++ b/lib/nodejs/supervisor.ex
@@ -84,10 +84,11 @@ defmodule NodeJS.Supervisor do
     path = Keyword.fetch!(opts, :path)
     pool_size = Keyword.get(opts, :pool_size, @default_pool_size)
     pool_name = get_pool_name(opts)
+    worker = Keyword.get(opts, :worker, NodeJS.Worker)
 
     pool_opts = [
       name: {:local, pool_name},
-      worker_module: NodeJS.Worker,
+      worker_module: worker,
       size: pool_size,
       max_overflow: 0
     ]

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -11,9 +11,9 @@ defmodule NodeJS.Worker do
   @doc """
   Starts the Supervisor and underlying node service.
   """
-  @spec start_link([binary()]) :: {:ok, pid} | {:error, any()}
-  def start_link([module_path]) do
-    GenServer.start_link(__MODULE__, module_path)
+  @spec start_link([binary()], any()) :: {:ok, pid} | {:error, any()}
+  def start_link([module_path], opts \\ []) do
+    GenServer.start_link(__MODULE__, module_path, name: Keyword.get(opts, :name))
   end
 
   # Node.js REPL Service


### PR DESCRIPTION
I recently ran into a requirement where I had an umbrella where two of the apps both needed to use `elixir-nodejs`.  This turned out not to be possible since the `name` and the pool name are hardcoded.  Therefore this PR adds a `name` option which allows the name (and hence the pool) to be specified when creating the supervisor.