### PR TITLE
Add failing test for console.log statements

### DIFF
--- a/priv/server.js
+++ b/priv/server.js
@@ -2,6 +2,8 @@ const path = require('path')
 const readline = require('readline')
 const WRITE_CHUNK_SIZE = parseInt(process.env.WRITE_CHUNK_SIZE, 10)
 
+const PREFIX = "__elixirnodejs__UOSBsDUP6bp9IF5__";
+
 function requireModule(modulePath) {
   // When not running in production mode, refresh the cache on each call.
   if (process.env.NODE_ENV !== 'production') {
@@ -50,6 +52,10 @@ async function getResponse(string) {
 async function onLine(string) {
   const buffer = Buffer.from(`${await getResponse(string)}\n`)
 
+  // The function we called might have written something to stdout without starting a new line.
+  // So we add one here and write the response after the prefix
+  process.stdout.write("\n")
+  process.stdout.write(PREFIX)
   for (let i = 0; i < buffer.length; i += WRITE_CHUNK_SIZE) {
     let chunk = buffer.slice(i, i + WRITE_CHUNK_SIZE)
 

--- a/test/js/keyed-functions.js
+++ b/test/js/keyed-functions.js
@@ -38,6 +38,12 @@ function getEnv() {
   return process.env
 }
 
+function logsSomething() {
+  console.log("Something")
+  process.stdout.write("something else")
+  return 42
+}
+
 module.exports = {
   uuid,
   hello,
@@ -47,4 +53,5 @@ module.exports = {
   getIncompatibleReturnValue,
   getArgv,
   getEnv,
+  logsSomething
 }

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -212,4 +212,10 @@ defmodule NodeJS.Test do
       assert_receive :received_error, 50
     end
   end
+
+  describe "console.log statements" do
+    test "don't crash NodeJS process" do
+      assert {:ok, 42} = NodeJS.call({"keyed-functions", :logsSomething}, [])
+    end
+  end
 end


### PR DESCRIPTION
Hi there :wave: 

Instead of creating an issue, I thought I'll add a failing unit test instead.

When using this library at work, we have the issue that log statements in JS code do crash the NodeJS worker process.
In our case, we are using a third party JS library that we don't control and this library sometimes uses log statements, which then kill the caller process.

---

The crash happens because the library uses stdout for the server protocol
https://github.com/revelrylabs/elixir-nodejs/blob/545211106f42c12408cef2091aedb964022fd7f9/priv/server.js#L65

Then, when calling `console.log`, this output is then thought to be part of the communication protocol and fails to decode here:
https://github.com/revelrylabs/elixir-nodejs/blob/545211106f42c12408cef2091aedb964022fd7f9/lib/nodejs/worker.ex#L95

---

To me it seems like the best way to solve this would be to use a different communication channel for the server process, maybe over a temporary unix socket.
But I don't know the best solution yet, maybe you have some other idea?