### PR TITLE
Send ignored messages to Logger.debug

### DIFF
--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -121,6 +121,14 @@ defmodule NodeJS.Worker do
     end
   end
 
+  def handle_info({_, {:data, {:eol, message}}}, state) do
+    if message != [] do
+      Logger.debug(message)
+    end
+
+    {:noreply, state}
+  end
+
   defp decode(data) do
     data
     |> to_string()

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -1,6 +1,8 @@
 defmodule NodeJS.Worker do
   use GenServer
 
+  require Logger
+
   # Port can't do more than this.
   @read_chunk_size 65_536
 
@@ -75,7 +77,11 @@ defmodule NodeJS.Worker do
               @prefix ++ protocol_data ->
                 {:ok, protocol_data}
 
-              _ ->
+              [] ->
+                get_response('', timeout)
+
+              message ->
+                Logger.debug(message)
                 get_response('', timeout)
             end
         end


### PR DESCRIPTION
With this change, messages from `console.log`, or other functions that write to stdin, are sent to `Logger.debug`. It makes it easier to debug JavaScript code.