### PR TITLE
import Config and test fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: elixir
 elixir:
   - 1.14
 otp_release:
-  - 21.0
+  - 25.0
 cache:
   directories:
     - _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.7
+  - 1.14
 otp_release:
   - 21.0
 cache:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule NodeJS.MixProject do
     [
       app: :nodejs,
       version: "2.0.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -86,7 +86,7 @@ defmodule NodeJS.Test do
 
     test "object does not exist" do
       assert {:error, msg} = NodeJS.call({"keyed-functions", :idontexist, :foo})
-      assert js_error_message(msg) === "TypeError: Cannot read property 'foo' of undefined"
+      assert js_error_message(msg) === "TypeError: Cannot read properties of undefined (reading 'foo')"
     end
   end
 


### PR DESCRIPTION
import Config instead of use Mix.Config as advised in the warning.

Updated required elixir version from 1.7 to 1.14

Change otp_release from 21.0 to 25.0

And apparently, the TypeError message changed in latest versions of node, thus making a test to fail, so I fixed it.