### PR TITLE
fix nodejs returning utf-8 chars

### DIFF
--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -117,6 +117,7 @@ defmodule NodeJS.Worker do
 
   defp decode(data) do
     data
+    |> IO.iodata_to_binary()
     |> to_string()
     |> Jason.decode!()
     |> case do

--- a/test/js/keyed-functions.js
+++ b/test/js/keyed-functions.js
@@ -44,6 +44,10 @@ function logsSomething() {
   return 42
 }
 
+function returnUTF8String() {
+  return {lang1: "中文", lang2: "hełło"}
+}
+
 module.exports = {
   uuid,
   hello,
@@ -53,5 +57,6 @@ module.exports = {
   getIncompatibleReturnValue,
   getArgv,
   getEnv,
-  logsSomething
+  logsSomething,
+  returnUTF8String
 }

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -218,4 +218,11 @@ defmodule NodeJS.Test do
       assert {:ok, 42} = NodeJS.call({"keyed-functions", :logsSomething}, [])
     end
   end
+
+  describe "utf-8 chars in response" do
+    test "using string instead of binary" do
+      assert {:ok, %{"lang1" => "中文", "lang2" => "hełło"}} =
+               NodeJS.call({"keyed-functions", :returnUTF8String}, [])
+    end
+  end
 end


### PR DESCRIPTION
## Problem:
When NodeJS returning strings contains UTF-8 chars, it would be convereted to binary instead of string. 

## Attempt fix
Using `IO.iodata_to_binary()` mentioned in [stackoverflow question](https://stackoverflow.com/questions/32927915/elixir-string-force-encode-utf-8)
