### PR TITLE
fix: correctly escape ansi characters when running in iEX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node-*.tar
 /node_modules/
 package-lock.json
 
+app

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -133,8 +133,14 @@ defmodule NodeJS.Worker do
     end
   end
 
+  defp reset_terminal(port) do
+    Port.command(port, "\x1b[0m\x1b[?7h\x1b[?25h\x1b[H\x1b[2J")
+    Port.command(port, "\x1b[!p\x1b[?47l")
+  end
+
   @doc false
   def terminate(_reason, [_, port]) do
+    reset_terminal(port)
     send(port, {self(), :close})
   end
 end

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -133,14 +133,8 @@ defmodule NodeJS.Worker do
     end
   end
 
-  defp reset_terminal(port) do
-    Port.command(port, "\x1b[0m\x1b[?7h\x1b[?25h\x1b[H\x1b[2J")
-    Port.command(port, "\x1b[!p\x1b[?47l")
-  end
-
   @doc false
   def terminate(_reason, [_, port]) do
-    reset_terminal(port)
     send(port, {self(), :close})
   end
 end

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -66,9 +66,7 @@ defmodule NodeJS.Worker do
   defp get_env_vars(module_path) do
     [
       {~c"NODE_PATH", node_path(module_path)},
-      {~c"WRITE_CHUNK_SIZE", String.to_charlist("#{@read_chunk_size}")},
-      # Disable Node.js warnings about experimental features
-      {~c"NODE_NO_WARNINGS", ~c"1"}
+      {~c"WRITE_CHUNK_SIZE", String.to_charlist("#{@read_chunk_size}")}
     ]
   end
 

--- a/test/js/terminal-test.js
+++ b/test/js/terminal-test.js
@@ -1,0 +1,33 @@
+// Test various ANSI sequences and terminal control characters
+module.exports = {
+  outputWithANSI: () => {
+    // Color and formatting
+    process.stdout.write('\u001b[31mred text\u001b[0m\n');
+    process.stdout.write('\u001b[1mbold text\u001b[0m\n');
+    
+    // Cursor movement
+    process.stdout.write('\u001b[2Amove up\n');
+    process.stdout.write('\u001b[2Bmove down\n');
+    
+    // Screen control
+    process.stdout.write('\u001b[2Jclear screen\n');
+    process.stdout.write('\u001b[?25linvisible cursor\n');
+    
+    // Return a clean string to verify protocol handling
+    return "clean output";
+  },
+
+  // Test function that outputs complex ANSI sequences
+  complexOutput: () => {
+    // Nested and compound sequences
+    process.stdout.write('\u001b[1m\u001b[31m\u001b[4mcomplex formatting\u001b[0m\n');
+    
+    // OSC sequences (window title, etc)
+    process.stdout.write('\u001b]0;Window Title\u0007');
+    
+    // Alternative screen buffer
+    process.stdout.write('\u001b[?1049h\u001b[Halternate screen\u001b[?1049l');
+    
+    return "complex test passed";
+  }
+}

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -256,4 +256,24 @@ defmodule NodeJS.Test do
       assert js_error_message(msg) =~ "ReferenceError: require is not defined in ES module scope"
     end
   end
+
+  describe "terminal handling" do
+    test "handles ANSI sequences without corrupting protocol" do
+      # Test basic ANSI handling - protocol messages should work
+      assert {:ok, "clean output"} = NodeJS.call({"terminal-test", "outputWithANSI"})
+      
+      # Test complex ANSI sequences - protocol messages should work
+      assert {:ok, "complex test passed"} = NodeJS.call({"terminal-test", "complexOutput"})
+      
+      # Test multiple processes don't interfere with each other
+      tasks = for _ <- 1..4 do
+        Task.async(fn ->
+          NodeJS.call({"terminal-test", "outputWithANSI"})
+        end)
+      end
+      
+      results = Task.await_many(tasks)
+      assert Enum.all?(results, &match?({:ok, "clean output"}, &1))
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the issue raised in https://github.com/revelrylabs/elixir-nodejs/issues/90

I spent a while debugging this issue, and narrowed it down to an issue with ANSI characters not being correctly escaped when running an app with this lib in its child processes, and running the app with iEX. 

I admit I struggled to completely fix it, but I had some AI help and was able to come up with something that works.  With this PR:
- tests pass, and the lib behaves as expected
- I can run an app with NodeJS in its supervision tree in iEX without messing up the terminal

I was also able to add a test to make sure further changes are not messing up with ansi escaping again.

Let me know what you guys think !