### PR TITLE
chore: bump version 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.2]
+
+### Changed
+- fix #90 terminal corruption when running inside an iEx session
+
+### Contributors
+- @francois-codes for the fix
+- @mrdotb and @Valian for contributing to the discussion
+
+
 ## [3.1.1]
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NodeJS.MixProject do
   def project do
     [
       app: :nodejs,
-      version: "3.1.1",
+      version: "3.1.2",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/nodejs_test.exs
+++ b/test/nodejs_test.exs
@@ -261,17 +261,18 @@ defmodule NodeJS.Test do
     test "handles ANSI sequences without corrupting protocol" do
       # Test basic ANSI handling - protocol messages should work
       assert {:ok, "clean output"} = NodeJS.call({"terminal-test", "outputWithANSI"})
-      
+
       # Test complex ANSI sequences - protocol messages should work
       assert {:ok, "complex test passed"} = NodeJS.call({"terminal-test", "complexOutput"})
-      
+
       # Test multiple processes don't interfere with each other
-      tasks = for _ <- 1..4 do
-        Task.async(fn ->
-          NodeJS.call({"terminal-test", "outputWithANSI"})
-        end)
-      end
-      
+      tasks =
+        for _ <- 1..4 do
+          Task.async(fn ->
+            NodeJS.call({"terminal-test", "outputWithANSI"})
+          end)
+        end
+
       results = Task.await_many(tasks)
       assert Enum.all?(results, &match?({:ok, "clean output"}, &1))
     end


### PR DESCRIPTION
- `mix format` to fix the build
- release version 3.1.2 with the fix for #90 