### PR TITLE
fix: implement handle_info/2

### DIFF
--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -12,6 +12,7 @@ defmodule NodeJS.Worker do
   @moduledoc """
   A genserver that controls the starting of the node service
   """
+  require Logger
 
   @doc """
   Starts the Supervisor and underlying node service.
@@ -123,10 +124,16 @@ defmodule NodeJS.Worker do
     end
   end
 
+  defp env do
+    Mix.env()
+  rescue
+    _ -> :release
+  end
+
   def handle_info({_pid, data}, state) do
-    with :dev <- Mix.env(),
+    with :dev <- env(),
          {_, {:eol, msg}} <- data do
-      IO.puts("NodeJS: #{msg}")
+      Logger.info("NodeJS: #{msg}")
     end
 
     {:noreply, state}

--- a/lib/nodejs/worker.ex
+++ b/lib/nodejs/worker.ex
@@ -123,6 +123,15 @@ defmodule NodeJS.Worker do
     end
   end
 
+  def handle_info({_pid, data}, state) do
+    with :dev <- Mix.env(),
+         {_, {:eol, msg}} <- data do
+      IO.puts("NodeJS: #{msg}")
+    end
+
+    {:noreply, state}
+  end
+
   defp decode(data) do
     data
     |> to_string()


### PR DESCRIPTION
When running the project again, I noticed some errors I didn't see before in the output:

![image](https://github.com/user-attachments/assets/6daa8d63-a5df-43dd-ab54-4c7254df5332)

This messages correspond to the messages sent by the nodejs for warnings and debugging info.

This PR fixes the problem by implementing the `handle_info/2` method, as advised in the error message. In order to avoid the spam, I added a check for `Mix.env()` to make sure we were only showing this information in dev.

This is the equivalent of the command above with this PR:

![image](https://github.com/user-attachments/assets/0984bb26-d439-48ab-893f-11f98b36f4b9)

FYI @Valian @grossvogel 