### PR TITLE
Added priv/package.json to mix package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,8 @@ defmodule NodeJS.MixProject do
         "README.md",
         "LICENSE",
         "CHANGELOG.md",
-        "priv/server.js"
+        "priv/server.js",
+        "priv/package.json"
       ],
       maintainers: ["Bryan Joseph", "Luke Ledet", "Joel Wietelmann"],
       licenses: ["MIT"],


### PR DESCRIPTION
Without that change, package.json is not added to the mix release.

Should fix https://github.com/revelrylabs/elixir-nodejs/issues/96